### PR TITLE
辞書の説明文の連結条件を改良

### DIFF
--- a/autoload/codic.vim
+++ b/autoload/codic.vim
@@ -95,12 +95,12 @@ endfunction
 function! s:LoadCSV(fname)
   let csv = []
   let line = ''
-  for curr in readfile(a:fname, 'b')
+  for curr in readfile(a:fname, 'r')
     if &enc !=# 'utf-8'
       let curr = iconv(curr, 'utf-8', &enc)
     endif
     let line .= curr
-    if curr =~# '\r$'
+    if curr !~# '"$'
       continue
     endif
     let vals = map(split(line, '"\zs,\ze"'), 'v:val[1:-2]')


### PR DESCRIPTION
gitの`core.autocrlf`を`false`にしてWindowsからcloneすると
naming-translation.csvの改行文字がCRになり、すべての行が
連結されて不正な形式になるので辞書が空になってしまいます。
代わりに各項目を囲むダブルクォートを連結条件にして辞書の
作成ミスを防ぎます。
