### PR TITLE
Can't open from nomodifiable-buffer

### DIFF
--- a/autoload/codic.vim
+++ b/autoload/codic.vim
@@ -226,7 +226,7 @@ function! s:OpenScratch(name)
   silent! execute 'pedit ' . escape(a:name, ' \')
   if bnum < 0
     silent! wincmd P
-    setlocal buftype=nofile noswapfile
+    setlocal buftype=nofile noswapfile modifiable
     silent! wincmd p
   end
   return bufnr(a:name)


### PR DESCRIPTION
Opening from nomodifiable-buffer, (ex. English help file) preview window is setted nomodifiable.
Because of this, s:Show functon is failed.
